### PR TITLE
[Fixed] ActionButton color is now visible

### DIFF
--- a/src/components/buttons/ActionButton.jsx
+++ b/src/components/buttons/ActionButton.jsx
@@ -1,6 +1,6 @@
 export default function ActionButton({ children }) {
     return (
-        <button className="px-5 py-2 border-3 rounded-lg font-light bg-white drop-shadow">
+        <button className="px-5 py-2 border-3 rounded-lg font-light bg-white drop-shadow text-(--primary-color)">
             {children}
         </button>
     )


### PR DESCRIPTION
* Button was appearing white because color property wasn't applied. This occured because during testing, the parent component was applying the color

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/a7ebe9c7-4683-42ce-ae23-42c1edd2ff5b) | ![image](https://github.com/user-attachments/assets/51049730-1e92-4cd3-b098-813d3167014b) | 