### PR TITLE
[Fixed] Added missing color to SearchBar Icon

### DIFF
--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -8,7 +8,7 @@ export default function SearchBar() {
                 placeholder="My Search Text"
                 className="px-6 py-2 min-w-100 w-40% max-w-624 border-3 border-(--primary-color) rounded-3xl drop-shadow-xl bg-white text-black font-light"
             />
-            <IoSearch className="absolute right-4 top-[15%] text-3xl" />
+            <IoSearch className="absolute right-4 top-[15%] text-3xl text-(--primary-color)" />
         </div>
     )
 }


### PR DESCRIPTION
| Before | After |
| --- | --- |
|  ![image](https://github.com/user-attachments/assets/220c4c81-eb40-43ac-a55a-4636affc530d) |  ![image](https://github.com/user-attachments/assets/c219db70-0d0d-45fe-96d5-141e1d554821) |