### PR TITLE
[Fix] SectionDivider undefined in className

### DIFF
--- a/src/components/divider/SectionDivider.jsx
+++ b/src/components/divider/SectionDivider.jsx
@@ -1,5 +1,5 @@
 export default function SectionDivider({ className }) {
     return (
-        <hr className={`${className} text-(--primary-color) border-2 rounded-xl`}/>
+        <hr className={`${className || ''} text-(--primary-color) border-2 rounded-xl`}/>
     )
 }


### PR DESCRIPTION
SectionDivider
* If no className is provided, then an empty string is given instead.
* This change stops undefined from appearing in `class` attribute