### PR TITLE
[FEAT] Search Card Redesign

### DIFF
--- a/src/components/cards/SearchResultCard.jsx
+++ b/src/components/cards/SearchResultCard.jsx
@@ -8,7 +8,7 @@ export default function SearchResultCard({title, text}) {
   return (
     <article
       onClick={navigateToArticle}
-      className="h-72 max-w-3xl hover:scale-115 ease-in-out duration-300 flex border-3 rounded-3xl shadow-xl border-gray-100 bg-white overflow-hidden cursor-pointer">
+      className="h-32 w-lg hover:scale-115 ease-in-out duration-300 flex border-3 rounded-3xl shadow-xl border-gray-100 bg-white overflow-hidden cursor-pointer">
       <div className="flex flex-1 gap-2 flex-col p-4">
         <header>
           <h2 className="text-xl text-gray-700 font-bold">{title}</h2>

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -20,7 +20,7 @@ export default function SearchPage() {
 
       <SectionDivider />
       <section className="w-full pb-16">
-        <ol className="grid grid-cols-1 gap-8 w-[60%] mx-auto">
+        <ol className="grid grid-cols-2 gap-8 justify-items-center">
           {searchResults.map((res, index) => (
             <li key={index}>
               <SearchResultCard title={res.title} text={res.text} />


### PR DESCRIPTION
SearchPage.jsx
* 2 Cards are displayed for each line now

SearchResultCard.jsx
* Decreased the size of card

![image](https://github.com/user-attachments/assets/2d045f52-d1ef-4a15-9a80-d07c35b0c9dd)
