### PR TITLE
[FEAT] SearchDropdown: Disappear on outside click

### DIFF
--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -1,21 +1,27 @@
 import {IoSearch} from 'react-icons/io5'
 import PropTypes from 'prop-types'
+import {forwardRef} from 'react'
 
-export default function SearchBar({searchTerm, onChange}) {
+const SearchBar = forwardRef(function SearchBar({searchTerm, onChange, onClick}, ref) {
   return (
     <div className="flex relative">
       <input
+        ref={ref}
         value={searchTerm}
         onChange={onChange}
+        onClick={onClick}
         placeholder="My Search Text"
         className="px-6 py-2 min-w-full xl:min-w-100 max-w-624 border-3 border-(--primary-color) rounded-3xl drop-shadow-xl bg-white text-black font-light focus:outline-none"
       />
       <IoSearch className="absolute right-4 top-[15%] text-3xl text-(--primary-color)" />
     </div>
   )
-}
+})
 
 SearchBar.propTypes = {
   searchTerm: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  onClick: PropTypes.func
 }
+
+export default SearchBar

--- a/src/hooks/useClickOutside.js
+++ b/src/hooks/useClickOutside.js
@@ -1,0 +1,14 @@
+import {useEffect, useRef} from 'react'
+
+export default function useClickOutside(callback) {
+  let ref = useRef()
+
+  useEffect(() => {
+    const handler = event => {
+      if (!ref.current?.contains(event.target)) callback()
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+  return ref
+}


### PR DESCRIPTION
# Changes
SearchForm.jsx
* New state variable `openMenu` for tracking dropdown menus visibility status
* renamed hasResults to showMenu. This is responsible for rendering the menu

useClickOutside.js
* Custom hook that detects when a given ref is no longer in focus (outside click)

SearchBar.jsx
* Now uses `forwardRef` to allow the propagating of `ref`
* Included an onClick handler to toggle the menu on and off when clicked

| Typing | Click Outside | 
| --- | --- |
| ![image](https://github.com/user-attachments/assets/440145e7-17a1-4e29-981c-cd433c61e70d) | ![image](https://github.com/user-attachments/assets/b177962d-6189-4993-a8af-f772779e6089) |