### PR TITLE
[FIX] SearchDropdown disppears on item click fix

### DIFF
--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -1,12 +1,10 @@
 import {IoSearch} from 'react-icons/io5'
 import PropTypes from 'prop-types'
-import {forwardRef} from 'react'
 
-const SearchBar = forwardRef(function SearchBar({searchTerm, onChange, onClick}, ref) {
+export default function SearchBar({searchTerm, onChange, onClick}) {
   return (
     <div className="flex relative">
       <input
-        ref={ref}
         value={searchTerm}
         onChange={onChange}
         onClick={onClick}
@@ -16,12 +14,10 @@ const SearchBar = forwardRef(function SearchBar({searchTerm, onChange, onClick},
       <IoSearch className="absolute right-4 top-[15%] text-3xl text-(--primary-color)" />
     </div>
   )
-})
+}
 
 SearchBar.propTypes = {
   searchTerm: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onClick: PropTypes.func
 }
-
-export default SearchBar

--- a/src/components/search/SearchDropdown.jsx
+++ b/src/components/search/SearchDropdown.jsx
@@ -1,13 +1,16 @@
 import PropTypes from 'prop-types'
+import {forwardRef} from 'react'
 import {useNavigate} from 'react-router-dom'
 
-export default function SearchDropdown({list}) {
+const SearchDropdown = forwardRef(function SearchDropdown({list}, ref) {
   const navigate = useNavigate()
   const navigateToArticle = title =>
     navigate(`/article/${encodeURIComponent(title)}`)
 
   return (
-    <ol className="absolute max-h-72 w-full overflow-y-scroll drop-shadow-md rounded-md bg-white z-(--modal-index)">
+    <ol
+      ref={ref}
+      className="absolute max-h-72 w-full overflow-y-scroll drop-shadow-md rounded-md bg-white z-(--modal-index)">
       {list.map((entry, index) => (
         <li
           onClick={() => navigateToArticle(entry.title)}
@@ -22,8 +25,10 @@ export default function SearchDropdown({list}) {
       ))}
     </ol>
   )
-}
+})
 
 SearchDropdown.propTypes = {
   list: PropTypes.array.isRequired
 }
+
+export default SearchDropdown

--- a/src/components/search/SearchForm.jsx
+++ b/src/components/search/SearchForm.jsx
@@ -62,7 +62,6 @@ export default function SearchForm({text}) {
       onSubmit={navigateToSearch}>
       <div className="relative">
         <SearchBar
-          ref={dropdownRef}
           onClick={() => setOpenMenu(!openMenu)}
           searchTerm={searchTerm}
           onChange={event => setSearchTerm(event.target.value)}
@@ -72,7 +71,9 @@ export default function SearchForm({text}) {
             {error}
           </p>
         )}
-        {showMenu() && <SearchDropdown list={searchResults} />}
+        {showMenu() && (
+          <SearchDropdown ref={dropdownRef} list={searchResults} />
+        )}
       </div>
       <ActionButton onClick={navigateToSearch}>Search</ActionButton>
     </form>


### PR DESCRIPTION
# Issue
* When attempting to click on an item from the SearchDropdown, the menu would disappear.
* `ref` was incorrectly passed to the SearchBar and not the SearchDropdown component

# Fix
* Moved `ref` to SearchDropdown

# Changes
SearchForm.jsx
* Removed `ref` code

SearchDropdown.jsx
* Moved `ref` functionality here

SearchForm.jsx
* Updated the location of dropdownRef to correct component